### PR TITLE
Add plaintext endpoint

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 
 # Register your models here.
+from django.urls import reverse
+from django.utils.html import format_html
+
 from core.models import Vision, Volume
 
 admin.site.register(Volume)
@@ -8,4 +11,8 @@ admin.site.register(Volume)
 @admin.register(Vision)
 class VisionAdmin(admin.ModelAdmin):
     fields = ('volume', 'visionary', 'guide', 'dose_origin', 'account',
-              'soul_status', 'ritual_results', 'commentary')
+              'soul_status', 'ritual_results', 'commentary', 'plain_text_link')
+    readonly_fields = ('plain_text_link',)
+
+    def plain_text_link(self, obj):
+        return format_html("<a href='{plain}'>{plain}</a>", plain=reverse("plain_text_vision", args=(obj.pk,)))

--- a/core/models.py
+++ b/core/models.py
@@ -47,3 +47,16 @@ class Vision(models.Model):
         Use the visionary's name and nation, which we've extracted.
         """
         return self.visionary
+
+    def plain_text_output(self):
+        output = []
+        if self.dose_origin:
+            output.append(str(self.dose_origin))
+        output.append(str(self.account))
+        if self.soul_status:
+            output.append(str(self.soul_status))
+        if self.ritual_results:
+            output.append(str(self.ritual_results))
+        if self.commentary:
+            output.append(str(self.commentary))
+        return "\n\n".join(output)

--- a/core/templates/plain_text_vision.txt
+++ b/core/templates/plain_text_vision.txt
@@ -1,0 +1,4 @@
+-{{ vision.visionary }}-
+Accompanied by {{ vision.guide }}
+
+{{ vision.plain_text_output|safe }}

--- a/core/templates/plain_text_vision.txt
+++ b/core/templates/plain_text_vision.txt
@@ -1,4 +1,4 @@
--{{ vision.visionary }}-
-Accompanied by {{ vision.guide }}
+-{{ vision.visionary|safe }}-
+Accompanied by {{ vision.guide|safe }}
 
 {{ vision.plain_text_output|safe }}

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('test', views.index, name='index'),
+    path('vision/<int:pk>/text', views.plain_text_vision, name="plain_text_vision")
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,8 @@
 from django.http import HttpResponse
 
 # Create your views here.
+from django.template.response import SimpleTemplateResponse
+
 from core.models import Vision
 
 
@@ -9,4 +11,5 @@ def index(request):
 
 def plain_text_vision(request, pk):
     vision = Vision.objects.get(pk=pk)
-    return HttpResponse(bytes(vision.account, encoding="utf8"), content_type="text/plain")
+    return SimpleTemplateResponse(template="plain_text_vision.txt", context={"vision": vision},
+                                  content_type="text/plain")

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,12 @@
 from django.http import HttpResponse
 
 # Create your views here.
+from core.models import Vision
+
+
 def index(request):
     return HttpResponse("Hello world - this is the initial index view.")
+
+def plain_text_vision(request, pk):
+    vision = Vision.objects.get(pk=pk)
+    return HttpResponse(bytes(vision.account, encoding="utf8"), content_type="text/plain")

--- a/echoes_cms/settings.py
+++ b/echoes_cms/settings.py
@@ -13,7 +13,9 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parents[1]
 
 
 # Quick-start development settings - unsuitable for production
@@ -55,7 +57,7 @@ ROOT_URLCONF = 'echoes_cms.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / "core/templates"],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
Add a URL endpoint to generate a plain-text version of a particular vision.

Also link to this endpoint in the admin page for that vision.