### PR TITLE
Ignore local virtualenv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 *.pyc
 **/.DS_Store
+.venv/*


### PR DESCRIPTION
My new laptop is set up to use pyenv-win and PyCharm's virtualenvs, which are created in .venv in the project directory, so we need to ignore those files as well.