### PR TITLE
Support multi-event text

### DIFF
--- a/core/templates/plain_text_volume.txt
+++ b/core/templates/plain_text_volume.txt
@@ -2,7 +2,7 @@
 {% load humanize %}
 --Echoes of the Labyrinth--
 
-{{ number_and_dates }}
+{{ numbers_and_dates }}
 
 A collection of notes on the experience of Pure Liao Visionaries, collected by
 
@@ -29,7 +29,7 @@ These notes were taken from verbal testimonies of witnessed events, so spellings
 
 ========
 
---{{ volume.volume_date }}-- {# should be "Winter Solstice, 381 YE" #}
+{% for volume in volumes %}--{{ volume.volume_date }}-- {# should be "Winter Solstice, 381 YE" #}
 
 -Introduction-
 
@@ -43,4 +43,4 @@ Following their visions, the visionaries and their accompanying guides were ques
 {% for vision in volume.list_of_visions%}
 {% include "plain_text_vision.txt" with vision=vision %}
 
-{% endfor %}
+{% endfor %}{% endfor %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -6,5 +6,7 @@ urlpatterns = [
     path('test', views.index, name='index'),
     path('vision/<int:pk>/text', views.plain_text_vision, name="plain_text_vision"),
     re_path('volume/(?P<volume_number>[1-9][0-9]*[a-d])/text', views.plain_text_single_volume,
-            name="plain_test_single_volume"),
+            name="plain_text_single_volume"),
+    path('volume/<int:volume_major_number>/text', views.plain_text_full_year,
+         name="plain_text_full_year")
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -76,3 +76,7 @@ def _plain_text_volume(request, volume_list):
 def plain_text_single_volume(request, volume_number):
     volume = Volume.objects.get(number=volume_number)
     return _plain_text_volume(request, [volume])
+
+def plain_text_full_year(request, volume_major_number):
+    volumes = Volume.objects.filter(number__regex=str(volume_major_number) + r"[a-d]").order_by('number')
+    return _plain_text_volume(request, volumes)

--- a/core/views.py
+++ b/core/views.py
@@ -70,7 +70,7 @@ def _plain_text_volume(request, volume_list):
                                       "front_page_credits": _front_page_credits_for_output(volume_list),
                                       "numbers_and_dates": _volume_number_dates_for_output(volume_list),
                                   },
-                                  content_type="text/plain")
+                                  content_type="text/plain; charset=utf-8")
 
 
 def plain_text_single_volume(request, volume_number):

--- a/core/views.py
+++ b/core/views.py
@@ -62,16 +62,17 @@ def _volume_number_dates_for_output(volume_list):
             first=sorted_volumes[0], last=sorted_volumes[-1]
         )
 
-def plain_text_single_volume(request, volume_number):
-    volume = Volume.objects.get(number=volume_number)
-    # TODO: When we've got this working as a single-event template, extend it to cover multiple events.
-    # TODO: Properly implement volume credits rather than just using the notes credits.
-    # TODO: Add the "N visionaries at this summit" paragraph, ideally with source attributions but optionally not.
+def _plain_text_volume(request, volume_list):
     return SimpleTemplateResponse(template="plain_text_volume.txt",
                                   context={
-                                      "volume": volume,
-                                      "contributor_credits": _contributor_credits_for_output([volume]),
-                                      "front_page_credits": _front_page_credits_for_output([volume]),
-                                      "number_and_dates": _volume_number_dates_for_output([volume]),
+                                      "volumes": volume_list,
+                                      "contributor_credits": _contributor_credits_for_output(volume_list),
+                                      "front_page_credits": _front_page_credits_for_output(volume_list),
+                                      "numbers_and_dates": _volume_number_dates_for_output(volume_list),
                                   },
                                   content_type="text/plain")
+
+
+def plain_text_single_volume(request, volume_number):
+    volume = Volume.objects.get(number=volume_number)
+    return _plain_text_volume(request, [volume])


### PR DESCRIPTION
So far, we have a view for getting plain text of a single event's visions. This PR implements another view that serves plain text of a full year's visions, through e.g. `/volume/2/text` rather than `/volume/2a/text`.