### PR TITLE
Add django-debug-toolbar

### DIFF
--- a/echoes_cms/settings.py
+++ b/echoes_cms/settings.py
@@ -42,10 +42,12 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'sortedm2m',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -125,3 +127,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+INTERNAL_IPS = [
+    '127.0.0.1',
+]

--- a/echoes_cms/urls.py
+++ b/echoes_cms/urls.py
@@ -18,5 +18,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('__debug__/', include('debug_toolbar.urls')),
     path('', include('core.urls')),
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,6 +39,18 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "3.4.0"
+description = "A configurable set of panels that display various debug information about the current request/response."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+Django = ">=3.2"
+sqlparse = ">=0.2.0"
+
+[[package]]
 name = "django-sortedm2m"
 version = "3.1.1"
 description = "Drop-in replacement for Django's many to many field with sorted relations."
@@ -65,7 +77,7 @@ python-versions = ">=2"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "2edcfc15281e9e2b588f1aaa92b04b02722dbced1bdc7648e086eece271e1ea8"
+content-hash = "4731d6439a83dacf5be8c7fce61d18401c2675752d3fd0fdf44ef52face4a357"
 
 [metadata.files]
 asgiref = [
@@ -93,6 +105,10 @@ asgiref = [
 django = [
     {file = "Django-4.0.5-py3-none-any.whl", hash = "sha256:502ae42b6ab1b612c933fb50d5ff850facf858a4c212f76946ecd8ea5b3bf2d9"},
     {file = "Django-4.0.5.tar.gz", hash = "sha256:f7431a5de7277966f3785557c3928433347d998c1e6459324501378a291e5aab"},
+]
+django-debug-toolbar = [
+    {file = "django-debug-toolbar-3.4.0.tar.gz", hash = "sha256:ae6bec2c1ce0e6900b0ab0443e1427eb233d8e6f57a84a0b2705eeecb8874e22"},
+    {file = "django_debug_toolbar-3.4.0-py3-none-any.whl", hash = "sha256:42c1c2e9dc05bb57b53d641e3a6d131fc031b92377b34ae32e604a1fe439bb83"},
 ]
 django-sortedm2m = [
     {file = "django-sortedm2m-3.1.1.tar.gz", hash = "sha256:136f3d4e0820b351608a7141d88ac3ba7fafcd37a9b8361ad00ffe616a790be5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Bouteillebleu"]
 python = "^3.8"
 Django = "^4.0.5"
 django-sortedm2m = "^3.1.1"
+django-debug-toolbar = "^3.4.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This is likely to be useful to debug some issues with context processors not being applied correctly in another branch, so I'll
add it now.

(All the setup required was installing the package and then following the steps in https://django-debug-toolbar.readthedocs.io/en/latest/installation.html. 👍 )